### PR TITLE
[WIP]出品した商品一覧ページの作成

### DIFF
--- a/app/assets/javascripts/exhibits.coffee
+++ b/app/assets/javascripts/exhibits.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/exhibits.scss
+++ b/app/assets/stylesheets/exhibits.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Exhibits controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/exhibits_controller.rb
+++ b/app/controllers/exhibits_controller.rb
@@ -1,0 +1,8 @@
+class ExhibitsController < ApplicationController
+  before_action :authenticate_user!
+  def index
+  end
+
+  def sold
+  end
+end

--- a/app/controllers/exhibits_controller.rb
+++ b/app/controllers/exhibits_controller.rb
@@ -1,8 +1,10 @@
 class ExhibitsController < ApplicationController
   before_action :authenticate_user!
   def index
+    @exhibits = current_user.exhibits.where(status: 1).or(current_user.exhibits.where(status: 3))
   end
 
   def sold
+    @exhibits = current_user.exhibits.where(status: 2)
   end
 end

--- a/app/helpers/exhibits_helper.rb
+++ b/app/helpers/exhibits_helper.rb
@@ -1,0 +1,2 @@
+module ExhibitsHelper
+end

--- a/app/views/exhibits/index.html.haml
+++ b/app/views/exhibits/index.html.haml
@@ -26,7 +26,7 @@
                         .user-container_right-content_info_content_list_detail_time
                           %i.far.fa-clock
                           - if exhibit.status == 1
-                            販売中
+                            出品中
                           - else 
                             公開停止中
                       .user-container_right-content_info_content_list_next

--- a/app/views/exhibits/index.html.haml
+++ b/app/views/exhibits/index.html.haml
@@ -1,2 +1,54 @@
-%h1 Exhibits#index
-%p Find me in app/views/exhibits/index.html.haml
+-breadcrumb :users 
+.user-main
+  .user-container
+    = render '/users/sidebar'
+    .user-container_right-content
+      .user-container_right-content_info
+        .user-container_right-content_info_content
+          .user-container_right-content_info_content
+            .user-container_right-content_info_content_title
+              %ul
+                %li{class: "active"}
+                  出品中
+                = link_to sold_exhibits_path do
+                  %li
+                    売却済み
+            .user-container_right-content_info_content_list
+              %ul
+                - @exhibits.each do |exhibit|
+                  %li
+                    = link_to item_path(exhibit.item.id) do
+                      .user-container_right-content_info_content_list_icon
+                        %img{alt: "メルカリ", height: "48px", width: "48px", src: "#{exhibit.item.item_images[0].image}"}
+                      .user-container_right-content_info_content_list_detail
+                        =exhibit.item.name
+                        を出品中
+                        .user-container_right-content_info_content_list_detail_time
+                          %i.far.fa-clock
+                          - if exhibit.status == 1
+                            販売中
+                          - else 
+                            公開停止中
+                      .user-container_right-content_info_content_list_next
+                        =fa_icon "angle-right"
+
+                %li{class: "user-container_right-content_info_content_list_go"}
+                  %a{ href: '#'}
+                    一覧を見る
+            -# .user-container_right-content_info_content_info
+            -#   %a{ href: 'http://google.co.jp'}
+            -#     一覧を見る
+      .user-container_right-content_items
+        .user-container_right-content_items_head
+          購入した商品
+        .user-container_right-content_items_title
+          %ul
+            %li{class: "active"}
+              取引中
+            %li
+              過去の取引
+        .user-container_right-content_items_list
+          .user-container_right-content_items_list_none
+            %img{alt: "メルカリ", height: "120px", width: "120px", src: "http://static.mercdn.net/images/mercari_profile.png", class: "user-container_right-content_items_list_none_image"}
+            %br
+            取引中の商品はありません。

--- a/app/views/exhibits/index.html.haml
+++ b/app/views/exhibits/index.html.haml
@@ -1,0 +1,2 @@
+%h1 Exhibits#index
+%p Find me in app/views/exhibits/index.html.haml

--- a/app/views/exhibits/sold.html.haml
+++ b/app/views/exhibits/sold.html.haml
@@ -1,2 +1,51 @@
-%h1 Exhibits#sold
-%p Find me in app/views/exhibits/sold.html.haml
+-breadcrumb :users 
+.user-main
+  .user-container
+    = render '/users/sidebar'
+    .user-container_right-content
+      .user-container_right-content_info
+        .user-container_right-content_info_content
+          .user-container_right-content_info_content
+            .user-container_right-content_info_content_title
+              %ul
+                %li{class: "active"}
+                  売却済み
+                = link_to exhibits_path do
+                  %li
+                    出品中
+            .user-container_right-content_info_content_list
+              %ul
+                - @exhibits.each do |exhibit|
+                  %li
+                    = link_to item_path(exhibit.item.id) do
+                      .user-container_right-content_info_content_list_icon
+                        %img{alt: "メルカリ", height: "48px", width: "48px", src: "#{exhibit.item.item_images[0].image}"}
+                      .user-container_right-content_info_content_list_detail
+                        =exhibit.item.name
+                        売却済
+                        .user-container_right-content_info_content_list_detail_time
+                          %i.far.fa-clock
+                          取引完了
+                      .user-container_right-content_info_content_list_next
+                        =fa_icon "angle-right"
+
+                %li{class: "user-container_right-content_info_content_list_go"}
+                  %a{ href: '#'}
+                    一覧を見る
+            -# .user-container_right-content_info_content_info
+            -#   %a{ href: 'http://google.co.jp'}
+            -#     一覧を見る
+      .user-container_right-content_items
+        .user-container_right-content_items_head
+          購入した商品
+        .user-container_right-content_items_title
+          %ul
+            %li{class: "active"}
+              取引中
+            %li
+              過去の取引
+        .user-container_right-content_items_list
+          .user-container_right-content_items_list_none
+            %img{alt: "メルカリ", height: "120px", width: "120px", src: "http://static.mercdn.net/images/mercari_profile.png", class: "user-container_right-content_items_list_none_image"}
+            %br
+            取引中の商品はありません。

--- a/app/views/exhibits/sold.html.haml
+++ b/app/views/exhibits/sold.html.haml
@@ -1,0 +1,2 @@
+%h1 Exhibits#sold
+%p Find me in app/views/exhibits/sold.html.haml

--- a/app/views/users/_sidebar.html.haml
+++ b/app/views/users/_sidebar.html.haml
@@ -27,7 +27,7 @@
             出品する
             .user-container_left-content_info_list
               =fa_icon "angle-right"
-        %a{ href: '#'}
+        = link_to exhibits_path do
           %li
             出品した商品 - 出品中
             .user-container_left-content_info_list
@@ -37,7 +37,7 @@
             出品した商品 - 取引中
             .user-container_left-content_info_list
               =fa_icon "angle-right"
-        %a{ href: '#'}
+        = link_to sold_exhibits_path do
           %li
             出品した商品 - 売却済み
             .user-container_left-content_info_list

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 Rails.application.routes.draw do
-  get 'exhibits/index'
-  get 'exhibits/sold'
+  
   devise_for :users, controllers: { 
     registrations: 'users/registrations',
     omniauth_callbacks: 'users/omniauth_callbacks'
@@ -30,5 +29,8 @@ Rails.application.routes.draw do
   root to: "items#index"
   get 'search', to: 'items#search'
   get 'purchased', to: 'purchases#purchased'
+  resources :exhibits, only: [:index] do
+    get 'sold', to: 'exhibits#sold', on: :collection
+  end
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get 'exhibits/index'
+  get 'exhibits/sold'
   devise_for :users, controllers: { 
     registrations: 'users/registrations',
     omniauth_callbacks: 'users/omniauth_callbacks'

--- a/spec/controllers/exhibits_controller_spec.rb
+++ b/spec/controllers/exhibits_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe ExhibitsController, type: :controller do
+
+  describe "GET #index" do
+    it "returns http success" do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET #sold" do
+    it "returns http success" do
+      get :sold
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/helpers/exhibits_helper_spec.rb
+++ b/spec/helpers/exhibits_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the ExhibitsHelper. For example:
+#
+# describe ExhibitsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe ExhibitsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/exhibits/index.html.haml_spec.rb
+++ b/spec/views/exhibits/index.html.haml_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "exhibits/index.html.haml", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/exhibits/sold.html.haml_spec.rb
+++ b/spec/views/exhibits/sold.html.haml_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "exhibits/sold.html.haml", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# WHAT
- exhibitsコントローラーの作成(add authenticate_user)
- 出品済み商品一覧のページ(view exhibits index)
- 売却済商品一覧ページの作成(view exhibits sold)
- mypageには出品停止中(status3)を表示しないようにする

# WHY
自分の出品商品を管理できるようにするため